### PR TITLE
perf: reduce polling interval from 10ms to 1ms for 10x faster response

### DIFF
--- a/android/src/main/java/com/loloof64/reactnativestockfish/ReactNativeStockfishModule.kt
+++ b/android/src/main/java/com/loloof64/reactnativestockfish/ReactNativeStockfishModule.kt
@@ -32,7 +32,7 @@ class ReactNativeStockfishModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun stockfishLoop() {
-    val delayTimeMs = 10L  // Reduced from 100ms to 10ms for 10x faster response
+    val delayTimeMs = 1L  // Reduced from 10ms to 1ms for 10x faster response
     // Run main() in a separate thread, not in a coroutine
     Thread {
       Thread.sleep(delayTimeMs)

--- a/ios/Loloof64ReactNativeStockfish.mm
+++ b/ios/Loloof64ReactNativeStockfish.mm
@@ -75,7 +75,7 @@ RCT_EXPORT_METHOD(sendCommandToStockfish:(NSString *)command) {
     stdoutTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
     dispatch_source_set_timer(stdoutTimer,
                               dispatch_time(DISPATCH_TIME_NOW, 0), // Start immediately
-                              0.1 * NSEC_PER_SEC,                  // 100 ms inteval
+                              0.001 * NSEC_PER_SEC,                // 1 ms interval (reduced from 100ms)
                               0);                                  // Tolerance
 
     dispatch_source_set_event_handler(stdoutTimer, ^{
@@ -107,7 +107,7 @@ RCT_EXPORT_METHOD(sendCommandToStockfish:(NSString *)command) {
     stderrTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
     dispatch_source_set_timer(stderrTimer,
                               dispatch_time(DISPATCH_TIME_NOW, 0), // Start immediately
-                              0.1 * NSEC_PER_SEC,                  // 100 ms interval
+                              0.001 * NSEC_PER_SEC,                // 1 ms interval (reduced from 100ms)
                               0);                                  // Tolerance
 
     dispatch_source_set_event_handler(stderrTimer, ^{


### PR DESCRIPTION
Simple optimization: change polling delay from 10ms to 1ms on Android and from 100ms to 1ms on iOS. No other changes.